### PR TITLE
Allow Wayland socket and switch to fallback X11

### DIFF
--- a/com.github.dahenson.agenda.json
+++ b/com.github.dahenson.agenda.json
@@ -8,8 +8,8 @@
 	"command": "com.github.dahenson.agenda",
 	"finish-args": [
 		/* Wayland and X11 access */
-		/* "--socket=wayland", window decoration missing */
-		"--socket=x11",
+		"--socket=wayland",
+		"--socket=fallback-x11",
 		"--share=ipc",
 		"--metadata=X-DConf=migrate-path=/com/github/dahenson/agenda/"
 


### PR DESCRIPTION
I tested this on two systems and I get decorations as expected, so I don't think this is relevant any more.

Closes https://github.com/flathub/com.github.dahenson.agenda/issues/4